### PR TITLE
Fix/registration current user

### DIFF
--- a/Handlers/AuthForms.cs
+++ b/Handlers/AuthForms.cs
@@ -79,7 +79,6 @@ namespace SnackToSixPack.Classes
 
                 AnsiConsole.WriteLine();
                 AnsiConsole.Markup("[bold]Welcome[/]" + ",[green] " + usernameInput + "[/]!");
-                MenuHandler.ShowUserMenu();
                 running = false;
             }
         }

--- a/Handlers/MenuHandler.cs
+++ b/Handlers/MenuHandler.cs
@@ -45,8 +45,10 @@ namespace SnackToSixPack.Handlers
                 if (!exit)
                 {
                     AnsiConsole.WriteLine();
-                    AnsiConsole.Markup("[grey]Press any key to return to the main menu...[/]");
+                    AnsiConsole.Markup("[grey]Press any key to continue to the User menu...[/]");
                     Console.ReadKey(true);
+                    ShowUserMenu();
+                    
                 }
             }
         }

--- a/Handlers/RegistrationHandler.cs
+++ b/Handlers/RegistrationHandler.cs
@@ -104,6 +104,8 @@ namespace SnackToSixPack.Handlers
 
             SaveUsers(users);
 
+            Session.CurrentUser = newUser;
+
             AnsiConsole.MarkupLine("\n[bold green] Registration successful![/]");
             AnsiConsole.MarkupLine($"[yellow]Welcome, {username}![/]");
         }

--- a/Program.cs
+++ b/Program.cs
@@ -32,7 +32,7 @@ namespace SnackToSixPack
             };
             JSONHelper.SaveProfile(profile1);*/
 
-            AuthForms.ShowLogInForm();
+            //AuthForms.ShowLogInForm();
             //Authentication.TwoFactorAuth();
 
             //Registration Does user exist 


### PR DESCRIPTION
Set the newly registered user as the currentUser, otherwise currentUser is always null and the UserMenu won’t be shown, because it can only be displayed if a user is logged in.