### PR TITLE
add try-catch when reading file

### DIFF
--- a/Handlers/MenuHandler.cs
+++ b/Handlers/MenuHandler.cs
@@ -78,8 +78,16 @@ public static async Task ShowMainMenu()
                         profileHandler.UpdateProfile(Session.CurrentUser.Profile);
                         break;
                     case "Show Schedule":
-                        //JSONHelper.ReadWP();
+                    try
+                    {
+                        JSONHelper.ReadWP();
                         WPUI.ShowWPUI(JSONHelper.ReadWP());
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        AnsiConsole.MarkupLine("[red]No workout plan genereated yet.[/]");
+                        AnsiConsole.MarkupLine("Please generate a workout plan from User Menu.");
+                    }
                         break;
                     case "Create Workout Plan":
                         await AIMenu();
@@ -91,7 +99,7 @@ public static async Task ShowMainMenu()
                 if (Session.CurrentUser != null)
                 {
                     AnsiConsole.WriteLine();
-                    AnsiConsole.Markup("[grey]Press any key to return to the user menu...[/]");
+                    AnsiConsole.Markup("[grey]Press any key to return to the User Menu...[/]");
                     Console.ReadKey(true);
                 }
             }


### PR DESCRIPTION
if user hadn't generated a workout plan before entering Show Schedule, the program crashed. Added a try-catch when reading file. #107 